### PR TITLE
check length of corps using len() instead of list.count()

### DIFF
--- a/pinger/tasks.py
+++ b/pinger/tasks.py
@@ -151,7 +151,7 @@ def bootstrap_notification_tasks():
     corps = list(set(all_member_corps_in_audit.values_list(
         "character__corporation_id", flat=True)))
 
-    logger.warning(f"PINGER: Bootstrap found {corps.count()} to check.")
+    logger.warning(f"PINGER: Bootstrap found {len(corps)} to check.")
     # fire off tasks for each corp with active models
     for cid in corps:
         _, _, next_update = _get_cache_data_for_corp(cid)


### PR DESCRIPTION
```
allianceauthworker-2  | [2024-08-30 15:37:24,213: ERROR/MainProcess] Task pinger.tasks.bootstrapnotification_tasks[49acaea4-ed25-4c65-836d-d8b31d536b16] raised unexpected: TypeError('list.count() takes exactly one argument (0 given)')
allianceauth_worker-2  | Traceback (most recent call last):
allianceauth_worker-2  |   File "/usr/local/lib/python3.11/site-packages/celery/app/trace.py", line 453, in trace_task
allianceauth_worker-2  |     R = retval = fun(*args, **kwargs)
allianceauth_worker-2  |                  ^^^^^^^^^^^^^^^^^^^^
allianceauth_worker-2  |   File "/usr/local/lib/python3.11/site-packages/celery/app/trace.py", line 736, in __protected_call
allianceauth_worker-2  |     return self.run(*args, **kwargs)
allianceauth_worker-2  |            ^^^^^^^^^^^^^^^^^^^^^^^^^
allianceauth_worker-2  |   File "/home/allianceauth/.local/lib/python3.11/site-packages/pinger/tasks.py", line 154, in bootstrap_notification_tasks
allianceauth_worker-2  |     logger.warning(f"PINGER: Bootstrap found {corps.count()} to check.")
allianceauth_worker-2  |                                               ^^^^^^^^^^^^^
allianceauth_worker-2  | TypeError: list.count() takes exactly one argument (0 given)
```

Tested and working.