### PR TITLE
Configurable fuel pings

### DIFF
--- a/pinger/admin.py
+++ b/pinger/admin.py
@@ -288,3 +288,8 @@ class SettingsAdmin(admin.ModelAdmin):
 
 
 admin.site.register(models.PingerConfig, SettingsAdmin)
+
+class FuelThresholdAdmin(admin.ModelAdmin):
+    list_display = ["time_before", "message"]
+
+admin.site.register(models.StructureFuelThreshold, FuelThresholdAdmin)

--- a/pinger/models.py
+++ b/pinger/models.py
@@ -20,6 +20,11 @@ class PingType(models.Model):
         return self.name
 
 
+class StructureFuelThreshold(models.Model):
+    time_before = models.DurationField()
+    message = models.TextField()
+
+
 class DiscordWebhook(models.Model):
     nickname = models.TextField(default="Discord Webhook")
     discord_webhook = models.TextField()

--- a/pinger/models.py
+++ b/pinger/models.py
@@ -89,8 +89,6 @@ class FuelPingRecord(models.Model):
     last_message = models.TextField(default="", blank=True)
     date_empty = models.DateTimeField(
         null=True, default=None, blank=True)  # expiry
-    last_ping_time = models.IntegerField(
-        null=True, default=None, blank=True)  # hours remaining @last ping
 
     structure = models.ForeignKey(
         Structure, on_delete=models.CASCADE, null=True, default=None)

--- a/pinger/models.py
+++ b/pinger/models.py
@@ -22,7 +22,7 @@ class PingType(models.Model):
 
 class StructureFuelThreshold(models.Model):
     time_before = models.DurationField()
-    message = models.TextField()
+    message = models.TextField(unique=True)
 
 
 class DiscordWebhook(models.Model):


### PR DESCRIPTION
Allows for structure fuel alert thresholds to be configured by the user.

I could not see anywhere `last_ping_time` was actually consumed and the comment said hours and the code was passing in days. 

TODO:
- [ ] testing
- [ ] generate migrations