### PR TITLE
[FIX] More `evelinks` fixes

### DIFF
--- a/pinger/models.py
+++ b/pinger/models.py
@@ -3,6 +3,7 @@ import logging
 from datetime import timedelta
 
 from allianceauth.eveonline.models import EveAllianceInfo, EveCorporationInfo
+from allianceauth.eveonline.evelinks import dotlan, eveimageserver
 from corptools.models import MapRegion, Structure
 from django.core.exceptions import ValidationError
 from django.db import models
@@ -98,9 +99,9 @@ class FuelPingRecord(models.Model):
     def build_ping_ob(self, message):
         _title = f"{self.structure.name}"
 
-        _system_name = f"[{self.structure.system_name.name}](http://evemaps.dotlan.net/system/{self.structure.system_name.name.replace(' ', '_')})"
+        _system_name = f"[{self.structure.system_name.name}]({dotlan.solar_system_url(self.structure.system_name.name)})"
 
-        _url = f"https://imageserver.eveonline.com/Type/{self.structure.type_id}_64.png"
+        _url = eveimageserver.type_icon_url(self.structure.type_id, 64)
 
         _services = ",".join(self.structure.structureservice_set.filter(
             state='online').values_list('name', flat=True))
@@ -110,7 +111,7 @@ class FuelPingRecord(models.Model):
         corp_ticker = self.structure.corporation.corporation.corporation_ticker
         corp_name = self.structure.corporation.corporation.corporation_name
         corp_id = self.structure.corporation.corporation.corporation_id
-        footer = {"icon_url": f"https://imageserver.eveonline.com/Corporation/{corp_id}_64.png",
+        footer = {"icon_url": eveimageserver.corporation_logo_url(corp_id, 64),
                   "text": f"{corp_name} ({corp_ticker})"}
 
         custom_data = {'color': 15158332,

--- a/pinger/notifications/corporate.py
+++ b/pinger/notifications/corporate.py
@@ -87,10 +87,10 @@ class CorpAppInvitedMsg(NotificationPing):
 
         corp_id = self._notification.character.character.corporation_id
         corp_ticker = self._notification.character.character.corporation_ticker
-        corp_name = "[%s](https://zkillboard.com/search/%s/)" % \
+        corp_name = "[%s](%s)" % \
             (self._notification.character.character.corporation_name,
-             self._notification.character.character.corporation_name.replace(" ", "%20"))
-        footer = {"icon_url": "https://imageserver.eveonline.com/Corporation/%s_64.png" % (str(corp_id)),
+             zkillboard.corporation_url(corp_id))
+        footer = {"icon_url": eveimageserver.corporation_logo_url(corp_id, 64),
                   "text": "%s (%s)" % (self._notification.character.character.corporation_name, corp_ticker)}
 
         fields = [{'name': 'Character', 'value': f"[{app_char}]({evewho.character_url(app_char.eve_id)})", 'inline': True},
@@ -137,10 +137,10 @@ class CorpAppNewMsg(NotificationPing):
 
         corp_id = self._notification.character.character.corporation_id
         corp_ticker = self._notification.character.character.corporation_ticker
-        corp_name = "[%s](https://zkillboard.com/search/%s/)" % \
+        corp_name = "[%s](%s)" % \
             (self._notification.character.character.corporation_name,
-             self._notification.character.character.corporation_name.replace(" ", "%20"))
-        footer = {"icon_url": "https://imageserver.eveonline.com/Corporation/%s_64.png" % (str(corp_id)),
+             zkillboard.corporation_url(corp_id))
+        footer = {"icon_url": eveimageserver.corporation_logo_url(corp_id, 64),
                   "text": "%s (%s)" % (self._notification.character.character.corporation_name, corp_ticker)}
 
         fields = [{'name': 'Character', 'value': f"[{app_char}]({evewho.character_url(app_char.eve_id)})", 'inline': True},
@@ -184,10 +184,10 @@ class CorpAppRejectMsg(NotificationPing):
 
         corp_id = self._notification.character.character.corporation_id
         corp_ticker = self._notification.character.character.corporation_ticker
-        corp_name = "[%s](https://zkillboard.com/search/%s/)" % \
+        corp_name = "[%s](%s)" % \
             (self._notification.character.character.corporation_name,
-             self._notification.character.character.corporation_name.replace(" ", "%20"))
-        footer = {"icon_url": "https://imageserver.eveonline.com/Corporation/%s_64.png" % (str(corp_id)),
+             zkillboard.corporation_url(corp_id))
+        footer = {"icon_url": eveimageserver.corporation_logo_url(corp_id, 64),
                   "text": "%s (%s)" % (self._notification.character.character.corporation_name, corp_ticker)}
 
         fields = [{'name': 'Character', 'value': f"[{app_char}]({evewho.character_url(app_char.eve_id)})", 'inline': True},

--- a/pinger/notifications/moons.py
+++ b/pinger/notifications/moons.py
@@ -7,6 +7,8 @@ from django.utils.html import strip_tags
 from .base import NotificationPing
 from .helpers import filetime_to_dt
 
+from allianceauth.eveonline.evelinks import dotlan, eveimageserver
+
 logger = logging.getLogger(__name__)
 
 
@@ -36,7 +38,7 @@ class MoonminingExtractionFinished(NotificationPing):
             system_id=self._data['solarSystemID'])
 
         system_name = system_db.name
-        system_name = f"[{system_name}](http://evemaps.dotlan.net/system/{system_name.replace(' ', '_')})"
+        system_name = f"[{system_name}]({dotlan.solar_system_url(system_name)})"
 
         structure_type, _ = ctm.EveItemType.objects.get_or_create_from_esi(
             self._data['structureTypeID'])
@@ -54,7 +56,7 @@ class MoonminingExtractionFinished(NotificationPing):
         corp_id = self._notification.character.character.corporation_id
         corp_ticker = self._notification.character.character.corporation_ticker
 
-        footer = {"icon_url": "https://imageserver.eveonline.com/Corporation/%s_64.png" % (str(corp_id)),
+        footer = {"icon_url": eveimageserver.corporation_logo_url(corp_id, 64),
                   "text": "%s (%s)" % (self._notification.character.character.corporation_name, corp_ticker)}
 
         auto_time = filetime_to_dt(self._data['autoTime'])
@@ -118,7 +120,7 @@ class MoonminingAutomaticFracture(NotificationPing):
             system_id=self._data['solarSystemID'])
 
         system_name = system_db.name
-        system_name = f"[{system_name}](http://evemaps.dotlan.net/system/{system_name.replace(' ', '_')})"
+        system_name = f"[{system_name}]({dotlan.solar_system_url(system_name)})"
 
         structure_type, _ = ctm.EveItemType.objects.get_or_create_from_esi(
             self._data['structureTypeID'])
@@ -136,7 +138,7 @@ class MoonminingAutomaticFracture(NotificationPing):
         corp_id = self._notification.character.character.corporation_id
         corp_ticker = self._notification.character.character.corporation_ticker
 
-        footer = {"icon_url": "https://imageserver.eveonline.com/Corporation/%s_64.png" % (str(corp_id)),
+        footer = {"icon_url": eveimageserver.corporation_logo_url(corp_id, 64),
                   "text": "%s (%s)" % (self._notification.character.character.corporation_name, corp_ticker)}
 
         ores = {}
@@ -199,7 +201,7 @@ class MoonminingLaserFired(NotificationPing):
             system_id=self._data['solarSystemID'])
 
         system_name = system_db.name
-        system_name = f"[{system_name}](http://evemaps.dotlan.net/system/{system_name.replace(' ', '_')})"
+        system_name = f"[{system_name}]({dotlan.solar_system_url(system_name)})"
 
         structure_type, _ = ctm.EveItemType.objects.get_or_create_from_esi(
             self._data['structureTypeID'])
@@ -219,7 +221,7 @@ class MoonminingLaserFired(NotificationPing):
         corp_id = self._notification.character.character.corporation_id
         corp_ticker = self._notification.character.character.corporation_ticker
 
-        footer = {"icon_url": "https://imageserver.eveonline.com/Corporation/%s_64.png" % (str(corp_id)),
+        footer = {"icon_url": eveimageserver.corporation_logo_url(corp_id, 64),
                   "text": "%s (%s)" % (self._notification.character.character.corporation_name, corp_ticker)}
 
         ores = {}
@@ -284,7 +286,7 @@ class MoonminingExtractionStarted(NotificationPing):
             system_id=self._data['solarSystemID'])
 
         system_name = system_db.name
-        system_name = f"[{system_name}](http://evemaps.dotlan.net/system/{system_name.replace(' ', '_')})"
+        system_name = f"[{system_name}]({dotlan.solar_system_url(system_name)})"
 
         structure_type, _ = ctm.EveItemType.objects.get_or_create_from_esi(
             self._data['structureTypeID'])
@@ -304,7 +306,7 @@ class MoonminingExtractionStarted(NotificationPing):
         corp_id = self._notification.character.character.corporation_id
         corp_ticker = self._notification.character.character.corporation_ticker
 
-        footer = {"icon_url": "https://imageserver.eveonline.com/Corporation/%s_64.png" % (str(corp_id)),
+        footer = {"icon_url": eveimageserver.corporation_logo_url(corp_id, 64),
                   "text": "%s (%s)" % (self._notification.character.character.corporation_name, corp_ticker)}
 
         auto_time = filetime_to_dt(self._data['autoTime'])

--- a/pinger/notifications/orbital.py
+++ b/pinger/notifications/orbital.py
@@ -2,6 +2,7 @@
 import datetime
 import logging
 
+from allianceauth.eveonline.evelinks import dotlan, eveimageserver, zkillboard
 from corptools import models as ctm
 
 from django.utils import timezone
@@ -39,8 +40,8 @@ class OrbitalAttacked(NotificationPing):
         region_name = system_db.constellation.region.name
         planet_name = planet_db.name
 
-        system_name = f"[{planet_name}](http://evemaps.dotlan.net/system/{system_name.replace(' ', '_')})"
-        region_name = f"[{region_name}](http://evemaps.dotlan.net/region/{region_name.replace(' ', '_')})"
+        system_name = f"[{planet_name}]({dotlan.solar_system_url(system_name)})"
+        region_name = f"[{region_name}]({dotlan.region_url(region_name)})"
 
         structure_type, _ = ctm.EveItemType.objects.get_or_create_from_esi(
             self._data['typeID'])
@@ -52,7 +53,7 @@ class OrbitalAttacked(NotificationPing):
 
         corp_id = self._notification.character.character.corporation_id
         corp_ticker = self._notification.character.character.corporation_ticker
-        footer = {"icon_url": "https://imageserver.eveonline.com/Corporation/%s_64.png" % (str(corp_id)),
+        footer = {"icon_url": eveimageserver.corporation_logo_url(corp_id, 64),
                   "text": "%s (%s)" % (self._notification.character.character.corporation_name, corp_ticker)}
 
         attacking_char, _ = ctm.EveName.objects.get_or_create_from_esi(
@@ -65,13 +66,10 @@ class OrbitalAttacked(NotificationPing):
             attacking_alli, _ = ctm.EveName.objects.get_or_create_from_esi(
                 self._data['aggressorAllianceID'])
 
-        attackerStr = "*[%s](https://zkillboard.com/search/%s/)*, [%s](https://zkillboard.com/search/%s/), **[%s](https://zkillboard.com/search/%s/)**" % \
-            (attacking_char.name,
-             attacking_char.name.replace(" ", "%20"),
-             attacking_corp.name,
-             attacking_corp.name.replace(" ", "%20"),
-             attacking_alli.name if attacking_alli else "*-*",
-             attacking_alli.name.replace(" ", "%20") if attacking_alli else "")
+        attackerStr = "%s, %s, %s" % \
+            (f"*[{attacking_char.name}]({zkillboard.character_url(attacking_char.eve_id)})*",
+             f"[{attacking_corp.name}]({zkillboard.corporation_url(attacking_corp.eve_id)})",
+             f"**[{attacking_alli.name}]({zkillboard.alliance_url(attacking_alli.eve_id)})**" if attacking_alli else "")
 
         fields = [{'name': 'System/Planet', 'value': system_name, 'inline': True},
                   {'name': 'Region', 'value': region_name, 'inline': True},
@@ -113,7 +111,7 @@ class OrbitalReinforced(NotificationPing):
 
         system_name = system_db.name
         planet_name = planet_db.name
-        system_name = f"[{planet_name}](http://evemaps.dotlan.net/system/{system_name.replace(' ', '_')})"
+        system_name = f"[{planet_name}]({dotlan.solar_system_url(system_name)})"
         structure_type, _ = ctm.EveItemType.objects.get_or_create_from_esi(
             self._data['typeID'])
 
@@ -127,10 +125,10 @@ class OrbitalReinforced(NotificationPing):
 
         corp_id = self._notification.character.character.corporation_id
         corp_ticker = self._notification.character.character.corporation_ticker
-        corp_name = "[%s](https://zkillboard.com/search/%s/)" % \
+        corp_name = "[%s](%s)" % \
             (self._notification.character.character.corporation_name,
-             self._notification.character.character.corporation_name.replace(" ", "%20"))
-        footer = {"icon_url": "https://imageserver.eveonline.com/Corporation/%s_64.png" % (str(corp_id)),
+             zkillboard.corporation_url(corp_id))
+        footer = {"icon_url": eveimageserver.corporation_logo_url(corp_id, 64),
                   "text": "%s (%s)" % (self._notification.character.character.corporation_name, corp_ticker)}
 
         fields = [{'name': 'System', 'value': system_name, 'inline': True},
@@ -211,8 +209,8 @@ class SkyhookUnderAttack(NotificationPing):
         region_name = system_db.constellation.region.name
         planet_name = planet_db.name
 
-        system_name = f"[{planet_name}](http://evemaps.dotlan.net/system/{system_name.replace(' ', '_')})"
-        region_name = f"[{region_name}](http://evemaps.dotlan.net/region/{region_name.replace(' ', '_')})"
+        system_name = f"[{planet_name}]({dotlan.solar_system_url(system_name)})"
+        region_name = f"[{region_name}]({dotlan.region_url(region_name)})"
 
         structure_type, _ = ctm.EveItemType.objects.get_or_create_from_esi(
             self._data['typeID'])
@@ -227,7 +225,7 @@ class SkyhookUnderAttack(NotificationPing):
 
         corp_id = self._notification.character.character.corporation_id
         corp_ticker = self._notification.character.character.corporation_ticker
-        footer = {"icon_url": "https://imageserver.eveonline.com/Corporation/%s_64.png" % (str(corp_id)),
+        footer = {"icon_url": eveimageserver.corporation_logo_url(corp_id, 64),
                   "text": "%s (%s)" % (self._notification.character.character.corporation_name, corp_ticker)}
 
         attacking_char, _ = ctm.EveName.objects.get_or_create_from_esi(
@@ -238,13 +236,10 @@ class SkyhookUnderAttack(NotificationPing):
         if self._data['allianceName']:
             attacking_alli = self._data['allianceName']
 
-        attackerStr = "*[%s](https://zkillboard.com/search/%s/)*, [%s](https://zkillboard.com/search/%s/), **[%s](https://zkillboard.com/search/%s/)**" % \
-            (attacking_char.name,
-             attacking_char.name.replace(" ", "%20"),
-             attacking_corp,
-             attacking_corp.replace(" ", "%20"),
-             attacking_alli if attacking_alli else "*-*",
-             attacking_alli.replace(" ", "%20") if attacking_alli else "")
+        attackerStr = "%s, %s, %s" % \
+            (f"*[{attacking_char.name}]({zkillboard.character_url(attacking_char.eve_id)})*",
+            f"[{attacking_corp.name}]({zkillboard.corporation_url(attacking_corp.eve_id)})",
+            f"**[{attacking_alli.name}]({zkillboard.alliance_url(attacking_alli.eve_id)})**" if attacking_alli else "")
 
         fields = [{'name': 'System/Planet', 'value': system_name, 'inline': True},
                   {'name': 'Region', 'value': region_name, 'inline': True},
@@ -293,7 +288,7 @@ class SkyhookLostShields(NotificationPing):
 
         system_name = system_db.name
         planet_name = planet_db.name
-        system_name = f"[{planet_name}](http://evemaps.dotlan.net/system/{system_name.replace(' ', '_')})"
+        system_name = f"[{planet_name}]({dotlan.solar_system_url(system_name)})"
         structure_type, _ = ctm.EveItemType.objects.get_or_create_from_esi(
             self._data['typeID'])
 
@@ -307,10 +302,10 @@ class SkyhookLostShields(NotificationPing):
 
         corp_id = self._notification.character.character.corporation_id
         corp_ticker = self._notification.character.character.corporation_ticker
-        corp_name = "[%s](https://zkillboard.com/search/%s/)" % \
+        corp_name = "[%s](%s)" % \
             (self._notification.character.character.corporation_name,
-             self._notification.character.character.corporation_name.replace(" ", "%20"))
-        footer = {"icon_url": "https://imageserver.eveonline.com/Corporation/%s_64.png" % (str(corp_id)),
+             zkillboard.corporation_url(corp_id))
+        footer = {"icon_url": eveimageserver.corporation_logo_url(corp_id, 64),
                   "text": "%s (%s)" % (self._notification.character.character.corporation_name, corp_ticker)}
 
         fields = [{'name': 'System', 'value': system_name, 'inline': True},
@@ -375,8 +370,8 @@ class SkyhookOnline(NotificationPing):
         region_name = system_db.constellation.region.name
         planet_name = planet_db.name
 
-        system_name = f"[{planet_name}](http://evemaps.dotlan.net/system/{system_name.replace(' ', '_')})"
-        region_name = f"[{region_name}](http://evemaps.dotlan.net/region/{region_name.replace(' ', '_')})"
+        system_name = f"[{planet_name}]({dotlan.solar_system_url(system_name)})"
+        region_name = f"[{region_name}]({dotlan.region_url(region_name)})"
 
         structure_type, _ = ctm.EveItemType.objects.get_or_create_from_esi(
             self._data['typeID'])
@@ -391,7 +386,7 @@ class SkyhookOnline(NotificationPing):
         corp_id = self._notification.character.character.corporation_id
         corp_ticker = self._notification.character.character.corporation_ticker
         footer = {
-            "icon_url": "https://imageserver.eveonline.com/Corporation/%s_64.png" % (str(corp_id)),
+            "icon_url": eveimageserver.corporation_logo_url(corp_id, 64),
             "text": f"{self._notification.character.character.corporation_name} ({corp_ticker})"
         }
 
@@ -449,8 +444,8 @@ class SkyhookDeployed(NotificationPing):
         region_name = system_db.constellation.region.name
         planet_name = planet_db.name
 
-        system_name = f"[{planet_name}](http://evemaps.dotlan.net/system/{system_name.replace(' ', '_')})"
-        region_name = f"[{region_name}](http://evemaps.dotlan.net/region/{region_name.replace(' ', '_')})"
+        system_name = f"[{planet_name}]({dotlan.solar_system_url(system_name)})"
+        region_name = f"[{region_name}]({dotlan.region_url(region_name)})"
 
         structure_type, _ = ctm.EveItemType.objects.get_or_create_from_esi(
             self._data['typeID'])
@@ -465,7 +460,7 @@ class SkyhookDeployed(NotificationPing):
         corp_id = self._notification.character.character.corporation_id
         corp_ticker = self._notification.character.character.corporation_ticker
         footer = {
-            "icon_url": "https://imageserver.eveonline.com/Corporation/%s_64.png" % (str(corp_id)),
+            "icon_url": eveimageserver.corporation_logo_url(corp_id, 64),
             "text": f"{self._notification.character.character.corporation_name} ({corp_ticker})"
         }
 
@@ -529,8 +524,8 @@ class MercenaryDenAttacked(NotificationPing):
         region_name = system_db.constellation.region.name
         planet_name = planet_db.name
 
-        system_name = f"[{planet_name}](http://evemaps.dotlan.net/system/{system_name.replace(' ', '_')})"
-        region_name = f"[{region_name}](http://evemaps.dotlan.net/region/{region_name.replace(' ', '_')})"
+        system_name = f"[{planet_name}]({dotlan.solar_system_url(system_name)})"
+        region_name = f"[{region_name}]({dotlan.region_url(region_name)})"
 
         structure_type, _ = ctm.EveItemType.objects.get_or_create_from_esi(
             self._data['typeID'])
@@ -545,19 +540,19 @@ class MercenaryDenAttacked(NotificationPing):
 
         corp_id = self._notification.character.character.corporation_id
         corp_ticker = self._notification.character.character.corporation_ticker
-        corp_name = "[%s](https://zkillboard.com/search/%s/)" % \
+        corp_name = "[%s](%s)" % \
             (self._notification.character.character.corporation_name,
-             self._notification.character.character.corporation_name.replace(" ", "%20"))
-        footer = {"icon_url": "https://imageserver.eveonline.com/Corporation/%s_64.png" % (str(corp_id)),
+             zkillboard.corporation_url(corp_id))
+        footer = {"icon_url": eveimageserver.corporation_logo_url(corp_id, 64),
                   "text": "%s (%s)" % (self._notification.character.character.corporation_name, corp_ticker)}
 
         attacking_char, _ = ctm.EveName.objects.get_or_create_from_esi(
             self._data['aggressorCharacterID'])
 
-        attackerStr = "[%s](https://zkillboard.com/character/%s/)" % \
+        attackerStr = "[%s](%s)" % \
             (
                 attacking_char.name,
-                attacking_char.eve_id
+                zkillboard.character_url(attacking_char.eve_id)
             )
 
         fields = [{'name': 'System/Planet', 'value': system_name, 'inline': True},
@@ -612,8 +607,8 @@ class MercenaryDenReinforced(NotificationPing):
         region_name = system_db.constellation.region.name
         planet_name = planet_db.name
 
-        system_name = f"[{planet_name}](http://evemaps.dotlan.net/system/{system_name.replace(' ', '_')})"
-        region_name = f"[{region_name}](http://evemaps.dotlan.net/region/{region_name.replace(' ', '_')})"
+        system_name = f"[{planet_name}]({dotlan.solar_system_url(system_name)})"
+        region_name = f"[{region_name}]({dotlan.region_url(region_name)})"
 
         structure_type, _ = ctm.EveItemType.objects.get_or_create_from_esi(
             self._data['typeID'])
@@ -628,10 +623,10 @@ class MercenaryDenReinforced(NotificationPing):
 
         corp_id = self._notification.character.character.corporation_id
         corp_ticker = self._notification.character.character.corporation_ticker
-        corp_name = "[%s](https://zkillboard.com/search/%s/)" % \
+        corp_name = "[%s](%s)" % \
             (self._notification.character.character.corporation_name,
-             self._notification.character.character.corporation_name.replace(" ", "%20"))
-        footer = {"icon_url": "https://imageserver.eveonline.com/Corporation/%s_64.png" % (str(corp_id)),
+             zkillboard.corporation_url(corp_id))
+        footer = {"icon_url": eveimageserver.corporation_logo_url(corp_id, 64),
                   "text": "%s (%s)" % (self._notification.character.character.corporation_name, corp_ticker)}
 
         fields = [{'name': 'System/Planet', 'value': system_name, 'inline': True},

--- a/pinger/notifications/sov.py
+++ b/pinger/notifications/sov.py
@@ -1,6 +1,7 @@
 import datetime
 import logging
 
+from allianceauth.eveonline.evelinks import dotlan, eveimageserver, zkillboard
 from corptools import models as ctm
 
 from .base import NotificationPing
@@ -40,7 +41,7 @@ class AllAnchoringMsg(NotificationPing):
             system_id=self._data['solarSystemID'])
 
         system_name = system_db.name
-        system_name = f"[{system_name}](http://evemaps.dotlan.net/system/{system_name.replace(' ', '_')})"
+        system_name = f"[{system_name}]({dotlan.solar_system_url(system_name)})"
 
         structure_type, _ = ctm.EveItemType.objects.get_or_create_from_esi(
             self._data['typeID'])
@@ -51,12 +52,13 @@ class AllAnchoringMsg(NotificationPing):
             self._data['corpID'])
 
         alliance = "-" if owner.alliance is None else owner.alliance.name
+        alliance_id = "-" if owner.alliance is None else owner.alliance.eve_id
 
         title = "Tower Anchoring!"
 
         body = (f"{structure_type.name}\n**{moon_name.name}**\n\n[{owner.name}]"
-                f"(https://zkillboard.com/search/{owner.name.replace(' ', '%20')}/),"
-                f" **[{alliance}](https://zkillboard.com/search/{alliance.replace(' ', '%20')}/)**")
+                f"({zkillboard.corporation_url(owner.eve_id)}),"
+                f" **[{alliance}]({zkillboard.alliance_url(alliance_id)})**")
 
         footer = {"icon_url": owner.get_image_url(),
                   "text": f"{owner.name}"}
@@ -105,8 +107,8 @@ class SovStructureReinforced(NotificationPing):
         system_name = system_db.name
         region_name = system_db.constellation.region.name
 
-        system_name = f"[{system_name}](http://evemaps.dotlan.net/system/{system_name.replace(' ', '_')})"
-        region_name = f"[{region_name}](http://evemaps.dotlan.net/region/{region_name.replace(' ', '_')})"
+        system_name = f"[{system_name}]({dotlan.solar_system_url(system_name)})"
+        region_name = f"[{region_name}]({dotlan.region_url(region_name)})"
 
         title = "Entosis notification"
         body = "Sov Struct Reinforced in %s" % system_name
@@ -125,7 +127,7 @@ class SovStructureReinforced(NotificationPing):
         alli_id = self._notification.character.character.alliance_id
         alli_ticker = self._notification.character.character.alliance_ticker
 
-        footer = {"icon_url": "https://images.evetech.net/alliances/%s/logo" % (str(alli_id)),
+        footer = {"icon_url": eveimageserver.alliance_logo_url(alli_id, 64),
                   "text": "%s (%s)" % (self._notification.character.character.alliance_name, alli_ticker)}
 
         fields = [{'name': 'System', 'value': system_name, 'inline': True},
@@ -178,8 +180,8 @@ class EntosisCaptureStarted(NotificationPing):
         system_name = system_db.name
         region_name = system_db.constellation.region.name
 
-        system_name = f"[{system_name}](http://evemaps.dotlan.net/system/{system_name.replace(' ', '_')})"
-        region_name = f"[{region_name}](http://evemaps.dotlan.net/region/{region_name.replace(' ', '_')})"
+        system_name = f"[{system_name}]({dotlan.solar_system_url(system_name)})"
+        region_name = f"[{region_name}]({dotlan.region_url(region_name)})"
 
         structure_type, _ = ctm.EveItemType.objects.get_or_create_from_esi(
             self._data['structureTypeID'])
@@ -192,7 +194,7 @@ class EntosisCaptureStarted(NotificationPing):
         alli_id = self._notification.character.character.alliance_id
         alli_ticker = self._notification.character.character.alliance_ticker
 
-        footer = {"icon_url": "https://images.evetech.net/alliances/%s/logo" % (str(alli_id)),
+        footer = {"icon_url": eveimageserver.alliance_logo_url(alli_id, 64),
                   "text": "%s (%s)" % (self._notification.character.character.alliance_name, alli_ticker)}
 
         fields = [{'name': 'System', 'value': system_name, 'inline': True},

--- a/pinger/notifications/structure.py
+++ b/pinger/notifications/structure.py
@@ -2,6 +2,7 @@ import datetime
 import logging
 import time
 
+from allianceauth.eveonline.evelinks import dotlan, eveimageserver, zkillboard
 from corptools import models as ctm
 from corptools.task_helpers.update_tasks import fetch_location_name
 
@@ -40,7 +41,7 @@ class StructureLostShields(NotificationPing):
             system_id=self._data['solarsystemID'])
 
         system_name = system_db.name
-        system_name = f"[{system_name}](http://evemaps.dotlan.net/system/{system_name.replace(' ', '_')})"
+        system_name = f"[{system_name}]({dotlan.solar_system_url(system_name)})"
 
         structure_type, _ = ctm.EveItemType.objects.get_or_create_from_esi(
             self._data['structureTypeID'])
@@ -67,10 +68,10 @@ class StructureLostShields(NotificationPing):
 
         corp_id = self._notification.character.character.corporation_id
         corp_ticker = self._notification.character.character.corporation_ticker
-        corp_name = "[%s](https://zkillboard.com/search/%s/)" % \
+        corp_name = "[%s](%s)" % \
             (self._notification.character.character.corporation_name,
-             self._notification.character.character.corporation_name.replace(" ", "%20"))
-        footer = {"icon_url": "https://imageserver.eveonline.com/Corporation/%s_64.png" % (str(corp_id)),
+             zkillboard.corporation_url(corp_id))
+        footer = {"icon_url": eveimageserver.corporation_logo_url(corp_id, 64),
                   "text": "%s (%s)" % (self._notification.character.character.corporation_name, corp_ticker)}
 
         fields = [{'name': 'System', 'value': system_name, 'inline': True},
@@ -130,7 +131,7 @@ class StructureLostArmor(NotificationPing):
             system_id=self._data['solarsystemID'])
 
         system_name = system_db.name
-        system_name = f"[{system_name}](http://evemaps.dotlan.net/system/{system_name.replace(' ', '_')})"
+        system_name = f"[{system_name}]({dotlan.solar_system_url(system_name)})"
 
         structure_type, _ = ctm.EveItemType.objects.get_or_create_from_esi(
             self._data['structureTypeID'])
@@ -157,10 +158,10 @@ class StructureLostArmor(NotificationPing):
 
         corp_id = self._notification.character.character.corporation_id
         corp_ticker = self._notification.character.character.corporation_ticker
-        corp_name = "[%s](https://zkillboard.com/search/%s/)" % \
+        corp_name = "[%s](%s)" % \
             (self._notification.character.character.corporation_name,
-             self._notification.character.character.corporation_name.replace(" ", "%20"))
-        footer = {"icon_url": "https://imageserver.eveonline.com/Corporation/%s_64.png" % (str(corp_id)),
+             zkillboard.corporation_url(corp_id))
+        footer = {"icon_url": eveimageserver.corporation_logo_url(corp_id, 64),
                   "text": "%s (%s)" % (self._notification.character.character.corporation_name, corp_ticker)}
 
         fields = [{'name': 'System', 'value': system_name, 'inline': True},
@@ -245,8 +246,8 @@ class StructureUnderAttack(NotificationPing):
         system_name = system_db.name
         region_name = system_db.constellation.region.name
 
-        system_name = f"[{system_name}](http://evemaps.dotlan.net/system/{system_name.replace(' ', '_')})"
-        region_name = f"[{region_name}](http://evemaps.dotlan.net/region/{region_name.replace(' ', '_')})"
+        system_name = f"[{system_name}]({dotlan.solar_system_url(system_name)})"
+        region_name = f"[{region_name}]({dotlan.region_url(region_name)})"
 
         structure_type, _ = ctm.EveItemType.objects.get_or_create_from_esi(
             self._data['structureTypeID'])
@@ -272,16 +273,16 @@ class StructureUnderAttack(NotificationPing):
 
         corp_id = self._notification.character.character.corporation_id
         corp_ticker = self._notification.character.character.corporation_ticker
-        # corp_name = "[%s](https://zkillboard.com/search/%s/)" % \
+        # corp_name = "[%s](%s)" % \
         #     (self._notification.character.character.corporation_name,
-        #      self._notification.character.character.corporation_name.replace(" ", "%20"))
-        footer = {"icon_url": "https://imageserver.eveonline.com/Corporation/%s_64.png" % (str(corp_id)),
+        #      zkillboard.corporation_url(corp_id))
+        footer = {"icon_url": eveimageserver.corporation_logo_url(corp_id, 64),
                   "text": "%s (%s)" % (self._notification.character.character.corporation_name, corp_ticker)}
 
         attacking_char, _ = ctm.EveName.objects.get_or_create_from_esi(
             self._data['charID'])
 
-        attackerStr = "*[%s](https://zkillboard.com/search/%s/)*, [%s](https://zkillboard.com/search/%s/), **[%s](https://zkillboard.com/search/%s/)**" % \
+        attackerStr = "*[%s](%s)*, [%s](%s), **[%s](%s)**" % \
             (attacking_char.name,
              attacking_char.name.replace(" ", "%20"),
              self._data.get('corpName', ""),
@@ -336,8 +337,8 @@ class OwnershipTransferred(NotificationPing):
         system_name = system_db.name
         region_name = system_db.constellation.region.name
 
-        system_name = f"[{system_name}](http://evemaps.dotlan.net/system/{system_name.replace(' ', '_')})"
-        region_name = f"[{region_name}](http://evemaps.dotlan.net/region/{region_name.replace(' ', '_')})"
+        system_name = f"[{system_name}]({dotlan.solar_system_url(system_name)})"
+        region_name = f"[{region_name}]({dotlan.region_url(region_name)})"
 
         structure_type, _ = ctm.EveItemType.objects.get_or_create_from_esi(
             self._data['structureTypeID'])
@@ -359,7 +360,7 @@ class OwnershipTransferred(NotificationPing):
         corp_id = self._notification.character.character.corporation_id
         corp_ticker = self._notification.character.character.corporation_ticker
 
-        footer = {"icon_url": "https://imageserver.eveonline.com/Corporation/%s_64.png" % (str(corp_id)),
+        footer = {"icon_url": eveimageserver.corporation_logo_url(corp_id, 64),
                   "text": "%s (%s)" % (self._notification.character.character.corporation_name, corp_ticker)}
 
         fields = []
@@ -415,8 +416,8 @@ class StructureAnchoring(NotificationPing):
         system_name = system_db.name
         region_name = system_db.constellation.region.name
 
-        system_name = f"[{system_name}](http://evemaps.dotlan.net/system/{system_name.replace(' ', '_')})"
-        region_name = f"[{region_name}](http://evemaps.dotlan.net/region/{region_name.replace(' ', '_')})"
+        system_name = f"[{system_name}]({dotlan.solar_system_url(system_name)})"
+        region_name = f"[{region_name}]({dotlan.region_url(region_name)})"
 
         structure_type, _ = ctm.EveItemType.objects.get_or_create_from_esi(
             self._data['structureTypeID'])
@@ -438,10 +439,10 @@ class StructureAnchoring(NotificationPing):
 
         corp_id = self._notification.character.character.corporation_id
         corp_ticker = self._notification.character.character.corporation_ticker
-        corp_name = "[%s](https://zkillboard.com/search/%s/)" % \
+        corp_name = "[%s](%s)" % \
             (self._notification.character.character.corporation_name,
-             self._notification.character.character.corporation_name.replace(" ", "%20"))
-        footer = {"icon_url": "https://imageserver.eveonline.com/Corporation/%s_64.png" % (str(corp_id)),
+             zkillboard.corporation_url(corp_id))
+        footer = {"icon_url": eveimageserver.corporation_logo_url(corp_id, 64),
                   "text": "%s (%s)" % (self._notification.character.character.corporation_name, corp_ticker)}
 
         fields = [{'name': 'Corporation', 'value': corp_name, 'inline': True},
@@ -483,8 +484,8 @@ class StructureWentLowPower(NotificationPing):
         system_name = system_db.name
         region_name = system_db.constellation.region.name
 
-        system_name = f"[{system_name}](http://evemaps.dotlan.net/system/{system_name.replace(' ', '_')})"
-        region_name = f"[{region_name}](http://evemaps.dotlan.net/region/{region_name.replace(' ', '_')})"
+        system_name = f"[{system_name}]({dotlan.solar_system_url(system_name)})"
+        region_name = f"[{region_name}]({dotlan.region_url(region_name)})"
 
         structure_type, _ = ctm.EveItemType.objects.get_or_create_from_esi(
             self._data['structureTypeID'])
@@ -506,10 +507,10 @@ class StructureWentLowPower(NotificationPing):
 
         corp_id = self._notification.character.character.corporation_id
         corp_ticker = self._notification.character.character.corporation_ticker
-        corp_name = "[%s](https://zkillboard.com/search/%s/)" % \
+        corp_name = "[%s](%s)" % \
             (self._notification.character.character.corporation_name,
-             self._notification.character.character.corporation_name.replace(" ", "%20"))
-        footer = {"icon_url": "https://imageserver.eveonline.com/Corporation/%s_64.png" % (str(corp_id)),
+             zkillboard.corporation_url(corp_id))
+        footer = {"icon_url": eveimageserver.corporation_logo_url(corp_id, 64),
                   "text": "%s (%s)" % (self._notification.character.character.corporation_name, corp_ticker)}
 
         fields = [{'name': 'Corporation', 'value': corp_name, 'inline': True},
@@ -553,8 +554,8 @@ class StructureWentHighPower(NotificationPing):
         system_name = system_db.name
         region_name = system_db.constellation.region.name
 
-        system_name = f"[{system_name}](http://evemaps.dotlan.net/system/{system_name.replace(' ', '_')})"
-        region_name = f"[{region_name}](http://evemaps.dotlan.net/region/{region_name.replace(' ', '_')})"
+        system_name = f"[{system_name}]({dotlan.solar_system_url(system_name)})"
+        region_name = f"[{region_name}]({dotlan.region_url(region_name)})"
 
         structure_type, _ = ctm.EveItemType.objects.get_or_create_from_esi(
             self._data['structureTypeID'])
@@ -576,10 +577,10 @@ class StructureWentHighPower(NotificationPing):
 
         corp_id = self._notification.character.character.corporation_id
         corp_ticker = self._notification.character.character.corporation_ticker
-        corp_name = "[%s](https://zkillboard.com/search/%s/)" % \
+        corp_name = "[%s](%s)" % \
             (self._notification.character.character.corporation_name,
-             self._notification.character.character.corporation_name.replace(" ", "%20"))
-        footer = {"icon_url": "https://imageserver.eveonline.com/Corporation/%s_64.png" % (str(corp_id)),
+             zkillboard.corporation_url(corp_id))
+        footer = {"icon_url": eveimageserver.corporation_logo_url(corp_id, 64),
                   "text": "%s (%s)" % (self._notification.character.character.corporation_name, corp_ticker)}
 
         fields = [{'name': 'Corporation', 'value': corp_name, 'inline': True},
@@ -629,8 +630,8 @@ class StructureUnanchoring(NotificationPing):
         system_name = system_db.name
         region_name = system_db.constellation.region.name
 
-        system_name = f"[{system_name}](http://evemaps.dotlan.net/system/{system_name.replace(' ', '_')})"
-        region_name = f"[{region_name}](http://evemaps.dotlan.net/region/{region_name.replace(' ', '_')})"
+        system_name = f"[{system_name}]({dotlan.solar_system_url(system_name)})"
+        region_name = f"[{region_name}]({dotlan.region_url(region_name)})"
 
         structure_type, _ = ctm.EveItemType.objects.get_or_create_from_esi(
             self._data['structureTypeID'])
@@ -652,10 +653,10 @@ class StructureUnanchoring(NotificationPing):
 
         corp_id = self._notification.character.character.corporation_id
         corp_ticker = self._notification.character.character.corporation_ticker
-        corp_name = "[%s](https://zkillboard.com/search/%s/)" % \
+        corp_name = "[%s](%s)" % \
             (self._notification.character.character.corporation_name,
-             self._notification.character.character.corporation_name.replace(" ", "%20"))
-        footer = {"icon_url": "https://imageserver.eveonline.com/Corporation/%s_64.png" % (str(corp_id)),
+             zkillboard.corporation_url(corp_id))
+        footer = {"icon_url": eveimageserver.corporation_logo_url(corp_id, 64),
                   "text": "%s (%s)" % (self._notification.character.character.corporation_name, corp_ticker)}
         date_out = time_till_to_dt(
             self._data['timeLeft'], self._notification.timestamp)
@@ -708,8 +709,8 @@ class StructureDestroyed(NotificationPing):
         system_name = system_db.name
         region_name = system_db.constellation.region.name
 
-        system_name = f"[{system_name}](http://evemaps.dotlan.net/system/{system_name.replace(' ', '_')})"
-        region_name = f"[{region_name}](http://evemaps.dotlan.net/region/{region_name.replace(' ', '_')})"
+        system_name = f"[{system_name}]({dotlan.solar_system_url(system_name)})"
+        region_name = f"[{region_name}]({dotlan.region_url(region_name)})"
 
         structure_type, _ = ctm.EveItemType.objects.get_or_create_from_esi(
             self._data['structureTypeID'])
@@ -731,10 +732,10 @@ class StructureDestroyed(NotificationPing):
 
         corp_id = self._notification.character.character.corporation_id
         corp_ticker = self._notification.character.character.corporation_ticker
-        corp_name = "[%s](https://zkillboard.com/search/%s/)" % \
+        corp_name = "[%s](%s)" % \
             (self._notification.character.character.corporation_name,
-             self._notification.character.character.corporation_name.replace(" ", "%20"))
-        footer = {"icon_url": "https://imageserver.eveonline.com/Corporation/%s_64.png" % (str(corp_id)),
+             zkillboard.corporation_url(corp_id))
+        footer = {"icon_url": eveimageserver.corporation_logo_url(corp_id, 64),
                   "text": "%s (%s)" % (self._notification.character.character.corporation_name, corp_ticker)}
 
         fields = [{'name': 'Corporation', 'value': corp_name, 'inline': True},
@@ -809,8 +810,8 @@ class StructureNoReagentsAlert(NotificationPing):
         system_name = system_db.name
         region_name = system_db.constellation.region.name
 
-        system_name = f"[{system_name}](http://evemaps.dotlan.net/system/{system_name.replace(' ', '_')})"
-        region_name = f"[{region_name}](http://evemaps.dotlan.net/region/{region_name.replace(' ', '_')})"
+        system_name = f"[{system_name}]({dotlan.solar_system_url(system_name)})"
+        region_name = f"[{region_name}]({dotlan.region_url(region_name)})"
 
         structure_type, _ = ctm.EveItemType.objects.get_or_create_from_esi(
             self._data['structureTypeID'])
@@ -832,10 +833,10 @@ class StructureNoReagentsAlert(NotificationPing):
 
         corp_id = self._notification.character.character.corporation_id
         corp_ticker = self._notification.character.character.corporation_ticker
-        corp_name = "[%s](https://zkillboard.com/search/%s/)" % \
+        corp_name = "[%s](%s)" % \
             (self._notification.character.character.corporation_name,
-             self._notification.character.character.corporation_name.replace(" ", "%20"))
-        footer = {"icon_url": "https://imageserver.eveonline.com/Corporation/%s_64.png" % (str(corp_id)),
+             zkillboard.corporation_url(corp_id))
+        footer = {"icon_url": eveimageserver.corporation_logo_url(corp_id, 64),
                   "text": "%s (%s)" % (self._notification.character.character.corporation_name, corp_ticker)}
         fields = [
             {'name': 'Corporation', 'value': corp_name, 'inline': True},
@@ -879,8 +880,8 @@ class StructureLowReagentsAlert(NotificationPing):
         system_name = system_db.name
         region_name = system_db.constellation.region.name
 
-        system_name = f"[{system_name}](http://evemaps.dotlan.net/system/{system_name.replace(' ', '_')})"
-        region_name = f"[{region_name}](http://evemaps.dotlan.net/region/{region_name.replace(' ', '_')})"
+        system_name = f"[{system_name}]({dotlan.solar_system_url(system_name)})"
+        region_name = f"[{region_name}]({dotlan.region_url(region_name)})"
 
         structure_type, _ = ctm.EveItemType.objects.get_or_create_from_esi(
             self._data['structureTypeID'])
@@ -905,10 +906,10 @@ class StructureLowReagentsAlert(NotificationPing):
 
         corp_id = self._notification.character.character.corporation_id
         corp_ticker = self._notification.character.character.corporation_ticker
-        corp_name = "[%s](https://zkillboard.com/search/%s/)" % \
+        corp_name = "[%s](%s)" % \
             (self._notification.character.character.corporation_name,
-             self._notification.character.character.corporation_name.replace(" ", "%20"))
-        footer = {"icon_url": "https://imageserver.eveonline.com/Corporation/%s_64.png" % (str(corp_id)),
+             zkillboard.corporation_url(corp_id))
+        footer = {"icon_url": eveimageserver.corporation_logo_url(corp_id, 64),
                   "text": "%s (%s)" % (self._notification.character.character.corporation_name, corp_ticker)}
         fields = [
             {'name': 'Corporation', 'value': corp_name, 'inline': True},

--- a/pinger/notifications/war.py
+++ b/pinger/notifications/war.py
@@ -1,3 +1,4 @@
+from allianceauth.eveonline.evelinks import eveimageserver
 from corptools import models as ctm
 from django.utils.html import strip_tags
 
@@ -34,7 +35,7 @@ class WarDeclared(NotificationPing):
 
         corp_id = self._notification.character.character.corporation_id
         corp_ticker = self._notification.character.character.corporation_ticker
-        footer = {"icon_url": "https://imageserver.eveonline.com/Corporation/%s_64.png" % (str(corp_id)),
+        footer = {"icon_url": eveimageserver.corporation_logo_url(corp_id, 64),
                   "text": "%s (%s)" % (self._notification.character.character.corporation_name, corp_ticker)}
 
         self.package_ping(title,

--- a/pinger/tasks.py
+++ b/pinger/tasks.py
@@ -9,6 +9,7 @@ from http.cookiejar import http2time
 import requests
 from bravado.exception import HTTPError
 from celery import shared_task
+from allianceauth.eveonline.evelinks import eveimageserver
 from corptools.models import (
     CharacterAudit, CorpAsset, CorporationAudit, Structure,
 )
@@ -354,7 +355,7 @@ def corporation_lo_check(self, corporation_id):
             }
 
             footer = {
-                "icon_url": "https://imageserver.eveonline.com/Corporation/%s_64.png" % (str(corporation_id)),
+                "icon_url": eveimageserver.corporation_logo_url(corporation_id, 64),
                 "text": f"{corp.corporation_name} ({corp.corporation_ticker})"
             }
 
@@ -514,7 +515,7 @@ def corporation_gas_check(self, corporation_id):
             }
 
             footer = {
-                "icon_url": "https://imageserver.eveonline.com/Corporation/%s_64.png" % (str(corporation_id)),
+                "icon_url": eveimageserver.corporation_logo_url(corporation_id, 64),
                 "text": f"{corp.corporation_name} ({corp.corporation_ticker})"
             }
 


### PR DESCRIPTION
In `pinger/notifications/moons.py` are still some zkillboard/search/ links left, since these are generated from an EVEHtml link.

Regex would be an option here, but I leave that to you. These are character links.